### PR TITLE
Fix all import paths: remove backend.app prefixes and use relative im…

### DIFF
--- a/backend/app/agents/agent_state.py
+++ b/backend/app/agents/agent_state.py
@@ -1,8 +1,8 @@
 from typing import Any, List, Optional
 from pydantic import BaseModel
 from langchain_core.messages import BaseMessage
-from backend.app.models.card import Deck
-from backend.app.models.schemas import DeckRequirements
+from app.models.card import Deck
+from app.models.schemas import DeckRequirements
 
 class AgentState(BaseModel):
     requirements: DeckRequirements

--- a/backend/app/agents/card_selector_agent.py
+++ b/backend/app/agents/card_selector_agent.py
@@ -3,11 +3,11 @@ from typing import Any, Dict
 from langchain_groq import ChatGroq
 from langchain_core.messages import AIMessage
 from langchain_core.prompts import ChatPromptTemplate,MessagesPlaceholder
-from backend.app.agents.agent_state import AgentState
-from backend.app.core.database import CardDatabase
-from backend.app.models.card import Card, Deck
-from backend.app.models.schemas import CardRole, ManaCost
-from backend.app.utils.utils import calculate_deck_statistics
+from app.agents.agent_state import AgentState
+from app.core.database import CardDatabase
+from app.models.card import Card, Deck
+from app.models.schemas import CardRole, ManaCost
+from app.utils.utils import calculate_deck_statistics
 
 
 class CardSelectorAgent:

--- a/backend/app/agents/deck_optimizer_agent.py
+++ b/backend/app/agents/deck_optimizer_agent.py
@@ -3,9 +3,9 @@ from typing import Any, Dict, List
 from langchain_groq import ChatGroq
 from langchain_core.messages import AIMessage
 from langchain_core.prompts import ChatPromptTemplate,MessagesPlaceholder
-from backend.app.agents.agent_state import AgentState
-from backend.app.models.card import  Deck
-from backend.app.utils.utils import calculate_deck_statistics, validate_mana_base
+from app.agents.agent_state import AgentState
+from app.models.card import Deck
+from app.utils.utils import calculate_deck_statistics, validate_mana_base
 
 
 class DeckOptimizerAgent:

--- a/backend/app/agents/example_how_to_use.py
+++ b/backend/app/agents/example_how_to_use.py
@@ -1,17 +1,17 @@
 import asyncio
 import json
 from langchain_groq import ChatGroq
-from backend.app.agents.agent_state import AgentState
-from backend.app.agents.card_selector_agent import CardSelectorAgent
-from backend.app.agents.deck_optimizer_agent import DeckOptimizerAgent
-from backend.app.agents.final_review_agent import FinalReviewerAgent
-from backend.app.agents.strategy_agent import StrategyAgent
-from backend.app.core.database import CardDatabase
-from backend.app.models.schemas import DeckRequirements
+from app.agents.agent_state import AgentState
+from app.agents.card_selector_agent import CardSelectorAgent
+from app.agents.deck_optimizer_agent import DeckOptimizerAgent
+from app.agents.final_review_agent import FinalReviewerAgent
+from app.agents.strategy_agent import StrategyAgent
+from app.core.database import CardDatabase
+from app.models.schemas import DeckRequirements
 from langchain_core.messages import HumanMessage
 from langgraph.graph import StateGraph, END
 
-from backend.app.core.config import settings
+from app.core.config import settings
 
 # Main Workflow
 def create_deck_building_graph(llm: ChatGroq, db: CardDatabase) -> StateGraph:

--- a/backend/app/agents/final_review_agent.py
+++ b/backend/app/agents/final_review_agent.py
@@ -3,8 +3,8 @@ from typing import Literal, Union
 from langchain_groq import ChatGroq
 from langchain_core.messages import AIMessage
 from langchain_core.prompts import ChatPromptTemplate,MessagesPlaceholder
-from backend.app.agents.agent_state import AgentState
-from backend.app.core.database import CardDatabase
+from app.agents.agent_state import AgentState
+from app.core.database import CardDatabase
 
 
 

--- a/backend/app/agents/strategy_agent.py
+++ b/backend/app/agents/strategy_agent.py
@@ -3,7 +3,7 @@ from langchain_core.messages import AIMessage
 from langchain_core.prompts import ChatPromptTemplate, MessagesPlaceholder
 from langchain_groq import ChatGroq
 
-from backend.app.agents.agent_state import AgentState
+from app.agents.agent_state import AgentState
 
 
 class StrategyAgent:

--- a/backend/app/models/card.py
+++ b/backend/app/models/card.py
@@ -1,7 +1,7 @@
 from collections import Counter
 from typing import Dict, List
 
-from core.database import Base
+from app.core.database import Base
 from sqlalchemy import (ARRAY, JSON, Column, DateTime, Float, ForeignKey, Index, Integer,
                         String, Table, func, text)
 from sqlalchemy.orm import relationship

--- a/backend/app/utils/utils.py
+++ b/backend/app/utils/utils.py
@@ -1,6 +1,6 @@
 from collections import Counter
 from typing import List
-from backend.app.models.schemas import DeckBase, DeckStatistics
+from app.models.schemas import DeckBase, DeckStatistics
 
 
 def calculate_deck_statistics(deck: DeckBase) -> DeckStatistics:


### PR DESCRIPTION
…ports

- Updated all files in /backend/app/agents/ directory to use app.* imports instead of backend.app.*
- Fixed agent_state.py imports (removed backend.app prefix)
- Fixed card_selector_agent.py imports
- Fixed deck_optimizer_agent.py imports
- Fixed strategy_agent.py imports
- Fixed final_review_agent.py imports
- Fixed example_how_to_use.py imports
- Fixed utils.py imports
- Fixed card.py to import from app.core.database instead of core.database
- This resolves circular import issues and standardizes import paths across the backend

🤖 Generated with [Claude Code](https://claude.com/claude-code)