### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -2,6 +2,8 @@ name: Pylint
 
 on: [push]
 
+permissions:
+  contents: read
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/redjoy12/MTGA_deck_builder/security/code-scanning/1](https://github.com/redjoy12/MTGA_deck_builder/security/code-scanning/1)

The best way to fix this problem is to explicitly set the `permissions` key in the workflow YAML. For this workflow, you can add `permissions: contents: read` at the workflow root level, above `jobs:`, so that all jobs inherit read-only access to repository contents by default. This change only affects the permissions granted to the GITHUB_TOKEN and does not otherwise alter workflow logic or behavior. All edits are confined to the .github/workflows/pylint.yml file; insert the block after the `name:` and before `jobs:` to ensure correct syntax and inheritance.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
