### PR TITLE
Add comprehensive Pydantic validators for deck building rules

### DIFF
--- a/backend/app/models/schemas.py
+++ b/backend/app/models/schemas.py
@@ -3,7 +3,7 @@ from datetime import datetime
 from enum import Enum
 from typing import Dict, List, Optional
 
-from pydantic import BaseModel, Field, validator
+from pydantic import BaseModel, Field, field_validator, model_validator
 
 
 
@@ -84,6 +84,23 @@ class CardBase(BaseModel):
     # Optional fields for additional functionality
     role: Optional[CardRole] = None  # Can be assigned based on card analysis
 
+    @field_validator('quantity')
+    @classmethod
+    def validate_quantity(cls, v):
+        """Validate that quantity is positive."""
+        if v <= 0:
+            raise ValueError('Card quantity must be positive')
+        return v
+
+    @field_validator('color_identity')
+    @classmethod
+    def validate_color_identity(cls, v):
+        """Validate that color identity contains valid MTG colors."""
+        valid_colors = {'W', 'U', 'B', 'R', 'G'}
+        if v and not all(color in valid_colors for color in v):
+            raise ValueError('Invalid color in color_identity')
+        return v
+
     class Config:
         use_enum_values = True
 
@@ -112,8 +129,9 @@ class DeckRequirements(BaseModel):
     budget_limit: Optional[float] = None
     constraints: Optional[str] = None
 
-    @validator('colors')
-    def validate_colors(cls, v):  # pylint: disable=no-self-argument
+    @field_validator('colors')
+    @classmethod
+    def validate_colors(cls, v):
         """Validate that colors are valid MTG color codes."""
         valid_colors = {'W', 'U', 'B', 'R', 'G'}
         if not all(color in valid_colors for color in v):
@@ -149,6 +167,31 @@ class CardCreate(BaseModel):
     card_faces: Optional[Dict] = None
     back_image_uri: Optional[str] = None
 
+    @field_validator('name')
+    @classmethod
+    def validate_name(cls, v):
+        """Validate that card name is not empty."""
+        if not v or len(v.strip()) == 0:
+            raise ValueError('Card name cannot be empty')
+        return v.strip()
+
+    @field_validator('color_identity')
+    @classmethod
+    def validate_color_identity(cls, v):
+        """Validate that color identity contains valid MTG colors."""
+        valid_colors = {'W', 'U', 'B', 'R', 'G'}
+        if v and not all(color in valid_colors for color in v):
+            raise ValueError('Invalid color in color_identity. Must be one of: W, U, B, R, G')
+        return v
+
+    @field_validator('cmc')
+    @classmethod
+    def validate_cmc(cls, v):
+        """Validate that CMC is non-negative."""
+        if v < 0:
+            raise ValueError('Converted mana cost (CMC) cannot be negative')
+        return v
+
 
 class CardResponse(CardBase):
     """Response schema for card information, used for API responses."""
@@ -162,7 +205,7 @@ class CardResponse(CardBase):
     layout: Optional[str] = None
 
     class Config:
-        orm_mode = True
+        from_attributes = True
 
 
 class DeckBase(BaseModel):
@@ -186,6 +229,81 @@ class DeckBase(BaseModel):
 
     statistics: Optional[DeckStatistics] = None
     total_cards: int = Field(default=60)
+
+    @field_validator('colors')
+    @classmethod
+    def validate_colors(cls, v):
+        """Validate that colors are valid MTG color codes."""
+        valid_colors = {'W', 'U', 'B', 'R', 'G'}
+        if not all(color in valid_colors for color in v):
+            raise ValueError('Invalid color code. Must be one of: W, U, B, R, G')
+        return v
+
+    @model_validator(mode='after')
+    def validate_deck_rules(self):
+        """Validate deck according to MTG rules."""
+        main_deck = self.main_deck
+        lands = self.lands
+        sideboard = self.sideboard
+        deck_colors = self.colors
+
+        # Combine all mainboard cards
+        all_mainboard = main_deck + lands
+
+        # 1. Deck size validation (minimum 60 cards)
+        total_mainboard = sum(card.quantity for card in all_mainboard)
+        if total_mainboard < 60:
+            raise ValueError(
+                f"Deck must have at least 60 cards in mainboard (currently {total_mainboard})"
+            )
+
+        # 2. Card quantity validation (max 4 except basic lands)
+        basic_lands = ["Plains", "Island", "Swamp", "Mountain", "Forest"]
+        card_counts = {}
+        for card in all_mainboard:
+            card_counts[card.name] = card_counts.get(card.name, 0) + card.quantity
+
+        for card_name, quantity in card_counts.items():
+            if quantity > 4:
+                # Check if it's a basic land by name or type_line
+                is_basic_land = card_name in basic_lands
+                if not is_basic_land:
+                    # Double-check by finding the card in the lists
+                    for card in all_mainboard:
+                        if card.name == card_name:
+                            if 'Basic Land' in card.type_line:
+                                is_basic_land = True
+                            break
+
+                if not is_basic_land:
+                    raise ValueError(
+                        f"Too many copies of '{card_name}' ({quantity}). "
+                        f"Maximum 4 copies allowed (except basic lands)"
+                    )
+
+        # 3. Sideboard size validation (max 15 cards)
+        sideboard_total = sum(card.quantity for card in sideboard)
+        if sideboard_total > 15:
+            raise ValueError(
+                f"Sideboard must have at most 15 cards (currently {sideboard_total})"
+            )
+
+        # 4. Color identity consistency validation
+        if deck_colors:
+            deck_color_set = set(deck_colors)
+            for card in all_mainboard + sideboard:
+                if card.color_identity:
+                    card_color_set = set(card.color_identity)
+                    if not card_color_set.issubset(deck_color_set):
+                        raise ValueError(
+                            f"Card '{card.name}' has colors {card.color_identity} "
+                            f"that are not in deck colors {deck_colors}"
+                        )
+
+        # Update total_cards
+        self.total_cards = total_mainboard
+
+        return self
 
     def validate_deck(self) -> List[str]:
         """
@@ -227,20 +345,66 @@ class DeckCreate(BaseModel):
     colors: List[str] = []
     strategy_tags: List[str] = []
 
-    @validator('name')
-    def validate_name(cls, v):  # pylint: disable=no-self-argument
+    @field_validator('name')
+    @classmethod
+    def validate_name(cls, v):
         """Validate that deck name is not empty."""
         if not v or len(v.strip()) == 0:
             raise ValueError('Deck name cannot be empty')
         return v.strip()
 
-    @validator('colors')
-    def validate_colors(cls, v):  # pylint: disable=no-self-argument
+    @field_validator('colors')
+    @classmethod
+    def validate_colors(cls, v):
         """Validate that colors are valid MTG color codes."""
         valid_colors = {'W', 'U', 'B', 'R', 'G'}
         if not all(color in valid_colors for color in v):
-            raise ValueError('Invalid color code')
+            raise ValueError('Invalid color code. Must be one of: W, U, B, R, G')
         return v
+
+    @field_validator('mainboard')
+    @classmethod
+    def validate_mainboard_quantities(cls, v):
+        """Validate that mainboard quantities are positive."""
+        for card_id, quantity in v.items():
+            if quantity <= 0:
+                raise ValueError(f"Card quantity must be positive for card {card_id}")
+        return v
+
+    @field_validator('sideboard')
+    @classmethod
+    def validate_sideboard_quantities(cls, v):
+        """Validate that sideboard quantities are positive."""
+        for card_id, quantity in v.items():
+            if quantity <= 0:
+                raise ValueError(f"Card quantity must be positive for card {card_id}")
+        return v
+
+    @model_validator(mode='after')
+    def validate_deck_creation_rules(self):
+        """Validate deck creation according to MTG rules."""
+        mainboard = self.mainboard
+        sideboard = self.sideboard
+
+        # 1. Validate mainboard size (minimum 60 cards)
+        mainboard_total = sum(mainboard.values())
+        if mainboard_total < 60:
+            raise ValueError(
+                f"Mainboard must have at least 60 cards (currently {mainboard_total})"
+            )
+
+        # 2. Validate sideboard size (maximum 15 cards)
+        sideboard_total = sum(sideboard.values())
+        if sideboard_total > 15:
+            raise ValueError(
+                f"Sideboard must have at most 15 cards (currently {sideboard_total})"
+            )
+
+        # Note: Card-specific validations (max 4 copies, basic lands, color identity)
+        # require card data lookup and are handled at the service/API layer
+        # These validators focus on structural constraints
+
+        return self
 
 
 class DeckResponse(BaseModel):
@@ -264,7 +428,7 @@ class DeckResponse(BaseModel):
     strategy_tags: List[str] = []
 
     class Config:
-        orm_mode = True
+        from_attributes = True
 
     def to_deck_base(self, card_lookup: Dict[str, 'Card']) -> DeckBase:
         """

--- a/backend/tests/test_validators.py
+++ b/backend/tests/test_validators.py
@@ -1,0 +1,337 @@
+"""Tests for Pydantic validators in schemas."""
+
+import pytest
+from pydantic import ValidationError
+
+from app.models.schemas import (
+    CardBase,
+    CardCreate,
+    DeckBase,
+    DeckCreate,
+    CardRole,
+)
+
+
+class TestCardBaseValidators:
+    """Test validators for CardBase model."""
+
+    def test_valid_card(self):
+        """Test creating a valid card."""
+        card = CardBase(
+            id="test-1",
+            name="Lightning Bolt",
+            mana_cost="{R}",
+            cmc=1.0,
+            color_identity=["R"],
+            quantity=4,
+            type_line="Instant",
+            rarity="common",
+            set_code="LEA",
+        )
+        assert card.name == "Lightning Bolt"
+        assert card.quantity == 4
+
+    def test_invalid_quantity_zero(self):
+        """Test that quantity cannot be zero."""
+        with pytest.raises(ValidationError) as exc_info:
+            CardBase(
+                id="test-1",
+                name="Lightning Bolt",
+                mana_cost="{R}",
+                cmc=1.0,
+                color_identity=["R"],
+                quantity=0,
+                type_line="Instant",
+                rarity="common",
+                set_code="LEA",
+            )
+        assert "Card quantity must be positive" in str(exc_info.value)
+
+    def test_invalid_quantity_negative(self):
+        """Test that quantity cannot be negative."""
+        with pytest.raises(ValidationError) as exc_info:
+            CardBase(
+                id="test-1",
+                name="Lightning Bolt",
+                mana_cost="{R}",
+                cmc=1.0,
+                color_identity=["R"],
+                quantity=-1,
+                type_line="Instant",
+                rarity="common",
+                set_code="LEA",
+            )
+        assert "Card quantity must be positive" in str(exc_info.value)
+
+    def test_invalid_color_identity(self):
+        """Test that color identity must contain valid colors."""
+        with pytest.raises(ValidationError) as exc_info:
+            CardBase(
+                id="test-1",
+                name="Lightning Bolt",
+                mana_cost="{R}",
+                cmc=1.0,
+                color_identity=["X"],
+                quantity=4,
+                type_line="Instant",
+                rarity="common",
+                set_code="LEA",
+            )
+        assert "Invalid color in color_identity" in str(exc_info.value)
+
+
+class TestCardCreateValidators:
+    """Test validators for CardCreate model."""
+
+    def test_valid_card_create(self):
+        """Test creating a valid card with CardCreate."""
+        card = CardCreate(
+            id="test-1",
+            name="Lightning Bolt",
+            type_line="Instant",
+            rarity="common",
+            set_code="LEA",
+            color_identity=["R"],
+            cmc=1.0,
+        )
+        assert card.name == "Lightning Bolt"
+
+    def test_empty_name(self):
+        """Test that card name cannot be empty."""
+        with pytest.raises(ValidationError) as exc_info:
+            CardCreate(
+                id="test-1",
+                name="",
+                type_line="Instant",
+                rarity="common",
+                set_code="LEA",
+            )
+        assert "Card name cannot be empty" in str(exc_info.value)
+
+    def test_invalid_cmc_negative(self):
+        """Test that CMC cannot be negative."""
+        with pytest.raises(ValidationError) as exc_info:
+            CardCreate(
+                id="test-1",
+                name="Test Card",
+                type_line="Instant",
+                rarity="common",
+                set_code="LEA",
+                cmc=-1.0,
+            )
+        assert "Converted mana cost (CMC) cannot be negative" in str(exc_info.value)
+
+
+class TestDeckBaseValidators:
+    """Test validators for DeckBase model."""
+
+    def create_test_card(self, name, quantity, type_line="Creature", colors=None):
+        """Helper to create a test card."""
+        if colors is None:
+            colors = ["R"]
+        return CardBase(
+            id=f"card-{name}",
+            name=name,
+            mana_cost="{R}",
+            cmc=1.0,
+            color_identity=colors,
+            quantity=quantity,
+            type_line=type_line,
+            rarity="common",
+            set_code="LEA",
+        )
+
+    def test_valid_deck(self):
+        """Test creating a valid 60-card deck."""
+        cards = [self.create_test_card(f"Card {i}", 4) for i in range(14)]
+        lands = [self.create_test_card("Mountain", 20, "Basic Land — Mountain")]
+
+        deck = DeckBase(
+            name="Test Deck",
+            format="Standard",
+            colors=["R"],
+            main_deck=cards,
+            lands=lands,
+        )
+        assert deck.total_cards == 76
+
+    def test_deck_too_small(self):
+        """Test that deck must have at least 60 cards."""
+        cards = [self.create_test_card("Card 1", 20)]
+
+        with pytest.raises(ValidationError) as exc_info:
+            DeckBase(
+                name="Test Deck",
+                format="Standard",
+                colors=["R"],
+                main_deck=cards,
+            )
+        assert "at least 60 cards" in str(exc_info.value)
+
+    def test_too_many_non_basic_cards(self):
+        """Test that non-basic cards cannot exceed 4 copies."""
+        cards = [self.create_test_card("Lightning Bolt", 5)]
+
+        with pytest.raises(ValidationError) as exc_info:
+            # Need 60 cards total
+            more_cards = [self.create_test_card(f"Card {i}", 4) for i in range(13)]
+            lands = [self.create_test_card("Mountain", 11, "Basic Land — Mountain")]
+
+            DeckBase(
+                name="Test Deck",
+                format="Standard",
+                colors=["R"],
+                main_deck=cards + more_cards,
+                lands=lands,
+            )
+        assert "Too many copies of 'Lightning Bolt'" in str(exc_info.value)
+        assert "Maximum 4 copies allowed" in str(exc_info.value)
+
+    def test_basic_lands_unlimited(self):
+        """Test that basic lands can have more than 4 copies."""
+        cards = [self.create_test_card(f"Card {i}", 4) for i in range(10)]
+        lands = [self.create_test_card("Mountain", 20, "Basic Land — Mountain")]
+
+        deck = DeckBase(
+            name="Test Deck",
+            format="Standard",
+            colors=["R"],
+            main_deck=cards,
+            lands=lands,
+        )
+        assert deck.total_cards == 60
+
+    def test_sideboard_too_large(self):
+        """Test that sideboard cannot exceed 15 cards."""
+        cards = [self.create_test_card(f"Card {i}", 4) for i in range(14)]
+        lands = [self.create_test_card("Mountain", 20, "Basic Land — Mountain")]
+        sideboard = [self.create_test_card(f"SB Card {i}", 4) for i in range(4)]
+
+        with pytest.raises(ValidationError) as exc_info:
+            DeckBase(
+                name="Test Deck",
+                format="Standard",
+                colors=["R"],
+                main_deck=cards,
+                lands=lands,
+                sideboard=sideboard,
+            )
+        assert "at most 15 cards" in str(exc_info.value)
+
+    def test_color_identity_mismatch(self):
+        """Test that cards must match deck colors."""
+        red_cards = [self.create_test_card(f"Card {i}", 4, colors=["R"]) for i in range(10)]
+        blue_card = [self.create_test_card("Blue Card", 4, colors=["U"])]
+        lands = [self.create_test_card("Mountain", 20, "Basic Land — Mountain", colors=["R"])]
+
+        with pytest.raises(ValidationError) as exc_info:
+            DeckBase(
+                name="Test Deck",
+                format="Standard",
+                colors=["R"],  # Deck is red only
+                main_deck=red_cards + blue_card,
+                lands=lands,
+            )
+        assert "not in deck colors" in str(exc_info.value)
+
+    def test_invalid_color_code(self):
+        """Test that color codes must be valid."""
+        cards = [self.create_test_card(f"Card {i}", 4) for i in range(14)]
+        lands = [self.create_test_card("Mountain", 20, "Basic Land — Mountain")]
+
+        with pytest.raises(ValidationError) as exc_info:
+            DeckBase(
+                name="Test Deck",
+                format="Standard",
+                colors=["X"],  # Invalid color
+                main_deck=cards,
+                lands=lands,
+            )
+        assert "Invalid color code" in str(exc_info.value)
+
+
+class TestDeckCreateValidators:
+    """Test validators for DeckCreate model."""
+
+    def test_valid_deck_create(self):
+        """Test creating a valid deck."""
+        deck = DeckCreate(
+            name="Test Deck",
+            format="Standard",
+            colors=["R"],
+            mainboard={"card-1": 4, "card-2": 4, "card-3": 52},
+            sideboard={"card-4": 15},
+        )
+        assert deck.name == "Test Deck"
+
+    def test_empty_deck_name(self):
+        """Test that deck name cannot be empty."""
+        with pytest.raises(ValidationError) as exc_info:
+            DeckCreate(
+                name="",
+                format="Standard",
+                colors=["R"],
+                mainboard={"card-1": 60},
+            )
+        assert "Deck name cannot be empty" in str(exc_info.value)
+
+    def test_mainboard_too_small(self):
+        """Test that mainboard must have at least 60 cards."""
+        with pytest.raises(ValidationError) as exc_info:
+            DeckCreate(
+                name="Test Deck",
+                format="Standard",
+                colors=["R"],
+                mainboard={"card-1": 30},
+            )
+        assert "at least 60 cards" in str(exc_info.value)
+
+    def test_sideboard_too_large(self):
+        """Test that sideboard cannot exceed 15 cards."""
+        with pytest.raises(ValidationError) as exc_info:
+            DeckCreate(
+                name="Test Deck",
+                format="Standard",
+                colors=["R"],
+                mainboard={"card-1": 60},
+                sideboard={"card-2": 20},
+            )
+        assert "at most 15 cards" in str(exc_info.value)
+
+    def test_invalid_mainboard_quantity(self):
+        """Test that mainboard quantities must be positive."""
+        with pytest.raises(ValidationError) as exc_info:
+            DeckCreate(
+                name="Test Deck",
+                format="Standard",
+                colors=["R"],
+                mainboard={"card-1": 0},
+            )
+        assert "Card quantity must be positive" in str(exc_info.value)
+
+    def test_invalid_sideboard_quantity(self):
+        """Test that sideboard quantities must be positive."""
+        with pytest.raises(ValidationError) as exc_info:
+            DeckCreate(
+                name="Test Deck",
+                format="Standard",
+                colors=["R"],
+                mainboard={"card-1": 60},
+                sideboard={"card-2": -1},
+            )
+        assert "Card quantity must be positive" in str(exc_info.value)
+
+    def test_invalid_color_code(self):
+        """Test that color codes must be valid."""
+        with pytest.raises(ValidationError) as exc_info:
+            DeckCreate(
+                name="Test Deck",
+                format="Standard",
+                colors=["X"],
+                mainboard={"card-1": 60},
+            )
+        assert "Invalid color code" in str(exc_info.value)
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/backend/tests/test_validators.py
+++ b/backend/tests/test_validators.py
@@ -8,7 +8,6 @@ from app.models.schemas import (
     CardCreate,
     DeckBase,
     DeckCreate,
-    CardRole,
 )
 
 


### PR DESCRIPTION
This commit adds comprehensive validation for all schemas using Pydantic V2 validators:

**CardBase validators:**
- Validate card quantity is positive (>0)
- Validate color identity contains only valid MTG colors (W, U, B, R, G)

**CardCreate validators:**
- Validate card name is not empty
- Validate color identity contains valid colors
- Validate CMC is non-negative

**DeckBase validators:**
- Validate colors are valid MTG color codes
- Validate deck size (minimum 60 cards in mainboard)
- Validate card quantity limits (max 4 copies except basic lands)
- Validate sideboard size (maximum 15 cards)
- Validate color identity consistency (all cards match deck colors)

**DeckCreate validators:**
- Validate deck name is not empty
- Validate colors are valid MTG color codes
- Validate mainboard and sideboard quantities are positive
- Validate mainboard size (minimum 60 cards)
- Validate sideboard size (maximum 15 cards)

**Additional improvements:**
- Updated all validators to use Pydantic V2 syntax (field_validator, model_validator)
- Updated Config classes from orm_mode to from_attributes (Pydantic V2)
- Added comprehensive test suite for all validators
- All validators properly recognize basic lands (by type_line) for unlimited copies

🤖 Generated with [Claude Code](https://claude.com/claude-code)