### PR TITLE
Remove unused backend dependencies

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -5,19 +5,13 @@ uvicorn
 # AI/ML Libraries
 langchain
 langgraph
-langchain-community
-langsmith
 langchain-groq
 
 # Database
 sqlalchemy==2.0.27
 alembic==1.13.1
-psycopg2-binary==2.9.9
-redis==5.0.1
-chromadb
 
 # Utils
-python-dotenv==1.0.1
 pydantic==2.6.1
 pydantic-settings
 python-jose==3.4.0


### PR DESCRIPTION
Removed 6 unused dependencies from requirements.txt:
- langchain-community (not imported anywhere)
- langsmith (not imported anywhere)
- chromadb (not imported anywhere)
- redis (configured but never used)
- psycopg2-binary (redundant with asyncpg)
- python-dotenv (replaced by pydantic-settings)

This reduces installation time and potential security surface while maintaining all required functionality.

🤖 Generated with [Claude Code](https://claude.com/claude-code)