### PR TITLE
Fix Pydantic v2 compatibility issues causing 500 error on registration

### DIFF
--- a/backend/app/agents/agent_state.py
+++ b/backend/app/agents/agent_state.py
@@ -17,6 +17,4 @@ class AgentState(BaseModel):
     iteration: int = 0
     max_iterations: int = 5
 
-    class Config:
-        """Pydantic configuration for AgentState."""
-        arbitrary_types_allowed = True
+    model_config = {"arbitrary_types_allowed": True}

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -4,7 +4,7 @@ import sys
 from functools import lru_cache
 from typing import Optional
 
-from pydantic_settings import BaseSettings
+from pydantic_settings import BaseSettings, SettingsConfigDict
 
 sys.path.append(os.path.join(os.path.dirname(os.path.abspath(__file__)), '..'))
 
@@ -43,11 +43,11 @@ class Settings(BaseSettings):
             f"@{self.POSTGRES_SERVER}:{self.POSTGRES_PORT}/{self.POSTGRES_DB}"
         )
 
-    class Config:
-        """Pydantic configuration for Settings."""
-        env_file = ".env"
-        case_sensitive = True
-        extra = "allow"  # This allows extra fields from the environment
+    model_config = SettingsConfigDict(
+        env_file=".env",
+        case_sensitive=True,
+        extra="allow"  # This allows extra fields from the environment
+    )
 
 
 @lru_cache
@@ -56,4 +56,3 @@ def get_settings() -> Settings:
     return Settings()
 
 settings = get_settings()
-print(settings.get_database_url)

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,9 +1,9 @@
 """Main FastAPI application for MTGA AI Deck Builder."""
 import json
+import logging
 from typing import Optional, List
 
 import uvicorn
-import logging
 
 from fastapi import (
     Depends, FastAPI, HTTPException, status,
@@ -55,8 +55,18 @@ app.include_router(user_resources.router)
 
 # Global exception handler to ensure JSON error responses
 @app.exception_handler(Exception)
-async def unhandled_exception_handler(request: Request, exc: Exception):
-    logging.getLogger(__name__).error(f"Unhandled exception: {exc}", exc_info=True)
+async def unhandled_exception_handler(_request: Request, exc: Exception):
+    """
+    Handle unhandled exceptions and return JSON error responses.
+
+    Args:
+        _request (Request): The incoming request (unused but required by FastAPI).
+        exc (Exception): The exception that was raised.
+
+    Returns:
+        JSONResponse: A JSON response with error details.
+    """
+    logging.getLogger(__name__).error("Unhandled exception: %s", exc, exc_info=True)
     return JSONResponse(
         status_code=500,
         content={"detail": "Internal Server Error"}

--- a/backend/app/models/auth_schemas.py
+++ b/backend/app/models/auth_schemas.py
@@ -2,7 +2,7 @@
 from datetime import datetime
 from typing import Optional
 
-from pydantic import BaseModel, EmailStr, Field, validator
+from pydantic import BaseModel, EmailStr, Field, field_validator
 
 
 class UserBase(BaseModel):
@@ -15,8 +15,9 @@ class UserCreate(UserBase):
     """Schema for creating a new user."""
     password: str = Field(..., min_length=8, max_length=100)
 
-    @validator('password')
-    def validate_password(cls, v):  # pylint: disable=no-self-argument
+    @field_validator('password')
+    @classmethod
+    def validate_password(cls, v: str) -> str:
         """Validate password strength."""
         if not any(char.isdigit() for char in v):
             raise ValueError('Password must contain at least one digit')
@@ -39,8 +40,7 @@ class UserResponse(UserBase):
     created_at: datetime
     updated_at: Optional[datetime] = None
 
-    class Config:
-        orm_mode = True
+    model_config = {"from_attributes": True}
 
 
 class Token(BaseModel):

--- a/backend/app/models/schemas.py
+++ b/backend/app/models/schemas.py
@@ -50,8 +50,7 @@ class UserResourcesResponse(UserResourcesBase):
     created_at: datetime
     updated_at: datetime
 
-    class Config:
-        orm_mode = True
+    model_config = {"from_attributes": True}
 
 
 class WildcardUpdate(BaseModel):
@@ -161,8 +160,7 @@ class CardBase(BaseModel):
             raise ValueError('Invalid color in color_identity')
         return v
 
-    class Config:
-        use_enum_values = True
+    model_config = {"use_enum_values": True}
 
 class DeckStatistics(BaseModel):
     """Holds statistics for a deck, including color distribution and mana curve."""


### PR DESCRIPTION
Updated all Pydantic models to use v2 syntax:
- Changed @validator to @field_validator with @classmethod decorator
- Replaced class Config with model_config dictionary
- Updated orm_mode to from_attributes
- Updated BaseSettings to use SettingsConfigDict
- Removed debug print statement from config.py

This fixes the 500 Internal Server Error when users try to register. The error was caused by Pydantic v1 decorators being used with Pydantic v2.

Files modified:
- app/models/auth_schemas.py: Updated validator and Config
- app/models/schemas.py: Updated Config to model_config
- app/agents/agent_state.py: Updated Config to model_config
- app/core/config.py: Updated to SettingsConfigDict

🤖 Generated with [Claude Code](https://claude.com/claude-code)