### PR TITLE
Fix bcrypt compatibility issue causing 500 error on registration

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -17,6 +17,7 @@ pydantic
 pydantic-settings
 python-jose
 passlib[bcrypt]
+bcrypt<4.0.0
 python-multipart
 asyncpg
 email-validator


### PR DESCRIPTION
Pin bcrypt version to <4.0.0 to resolve compatibility issue with passlib. Newer bcrypt versions (4.x+) removed the __about__ attribute that passlib relies on, causing AttributeError during password hashing.

This fixes the 500 Internal Server Error when users try to register.

🤖 Generated with [Claude Code](https://claude.com/claude-code)